### PR TITLE
Build: rename the root jar task into zip

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ tasks.named("build_4_antrunner") {
 }
 
 val antBuild: TaskProvider<Task> = tasks.named("ant-build")
-tasks.register("jar") {
+tasks.register("zip") {
     dependsOn(antBuild)
 }
 

--- a/integrationTests/build.gradle.kts
+++ b/integrationTests/build.gradle.kts
@@ -23,7 +23,7 @@ tasks.test {
 }
 
 val integrationTestTask = tasks.register<Test>("integrationTest") {
-    dependsOn(":jar")
+    dependsOn(":zip")
 
     description = "Runs integration tests."
     group = "verification"


### PR DESCRIPTION
It builds zip and not jar, so this is more appropriate.